### PR TITLE
[Test] Networking Response 파싱 테스트 추가

### DIFF
--- a/CAKK/CAKK.xcodeproj/project.pbxproj
+++ b/CAKK/CAKK.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		B41FE93B2A0C752A0072BC98 /* DetailInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41FE93A2A0C752A0072BC98 /* DetailInfoView.swift */; };
 		B424EA0029DC10D400B0C1CE /* SafeAreaGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424E9FF29DC10D400B0C1CE /* SafeAreaGuide.swift */; };
 		B43889B52A15B21700476BFC /* NaverMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43889B42A15B21700476BFC /* NaverMapView.swift */; };
+		B43889BD2A15DB4600476BFC /* CAKKNetworkingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43889BC2A15DB4600476BFC /* CAKKNetworkingTests.swift */; };
 		B43889C62A15E02300476BFC /* district_count_sample.json in Resources */ = {isa = PBXBuildFile; fileRef = B43889C52A15E02300476BFC /* district_count_sample.json */; };
 		B43DA3D229F8ACFA00F1A4B1 /* APIKeys.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = B43DA3D129F8ACFA00F1A4B1 /* APIKeys.xcconfig */; };
 		B43DA3D429F8B04900F1A4B1 /* UIViewController+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43DA3D329F8B04900F1A4B1 /* UIViewController+Preview.swift */; };
@@ -75,6 +76,16 @@
 		B4FB8E822A0F729900DBF193 /* DetailSectionTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FB8E812A0F729900DBF193 /* DetailSectionTitleView.swift */; };
 		B4FB8E842A0F7DA600DBF193 /* ShopDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FB8E832A0F7DA600DBF193 /* ShopDetailViewModel.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		B43889BE2A15DB4600476BFC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8E9E191B29CEDD4F00CFF157 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8E9E192229CEDD4F00CFF157;
+			remoteInfo = CAKK;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		014B174A5E6D2252FA1A52C8 /* Pods-CAKK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CAKK.debug.xcconfig"; path = "Target Support Files/Pods-CAKK/Pods-CAKK.debug.xcconfig"; sourceTree = "<group>"; };
@@ -118,6 +129,8 @@
 		B41FE93A2A0C752A0072BC98 /* DetailInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailInfoView.swift; sourceTree = "<group>"; };
 		B424E9FF29DC10D400B0C1CE /* SafeAreaGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaGuide.swift; sourceTree = "<group>"; };
 		B43889B42A15B21700476BFC /* NaverMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaverMapView.swift; sourceTree = "<group>"; };
+		B43889BA2A15DB4600476BFC /* CAKKNetworkingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CAKKNetworkingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B43889BC2A15DB4600476BFC /* CAKKNetworkingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAKKNetworkingTests.swift; sourceTree = "<group>"; };
 		B43889C52A15E02300476BFC /* district_count_sample.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = district_count_sample.json; sourceTree = "<group>"; };
 		B43DA3D129F8ACFA00F1A4B1 /* APIKeys.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = APIKeys.xcconfig; sourceTree = "<group>"; };
 		B43DA3D329F8B04900F1A4B1 /* UIViewController+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Preview.swift"; sourceTree = "<group>"; };
@@ -156,6 +169,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				9C7534055987407556BE848A /* Pods_CAKK.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B43889B72A15DB4600476BFC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -221,6 +241,7 @@
 			isa = PBXGroup;
 			children = (
 				8E9E192529CEDD4F00CFF157 /* CAKK */,
+				B43889BB2A15DB4600476BFC /* CAKKNetworkingTests */,
 				8E9E192429CEDD4F00CFF157 /* Products */,
 				D911E24E8132FA565E4A398E /* Pods */,
 				AD4B4F1E58EFB12089A0F251 /* Frameworks */,
@@ -231,6 +252,7 @@
 			isa = PBXGroup;
 			children = (
 				8E9E192329CEDD4F00CFF157 /* CAKK.app */,
+				B43889BA2A15DB4600476BFC /* CAKKNetworkingTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -326,6 +348,14 @@
 				1BA728E0477EEDD96A85FAA5 /* Pods_CAKK.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		B43889BB2A15DB4600476BFC /* CAKKNetworkingTests */ = {
+			isa = PBXGroup;
+			children = (
+				B43889BC2A15DB4600476BFC /* CAKKNetworkingTests.swift */,
+			);
+			path = CAKKNetworkingTests;
 			sourceTree = "<group>";
 		};
 		B455C4312A07E98A00FB8403 /* Store */ = {
@@ -431,6 +461,24 @@
 			productReference = 8E9E192329CEDD4F00CFF157 /* CAKK.app */;
 			productType = "com.apple.product-type.application";
 		};
+		B43889B92A15DB4600476BFC /* CAKKNetworkingTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B43889C22A15DB4600476BFC /* Build configuration list for PBXNativeTarget "CAKKNetworkingTests" */;
+			buildPhases = (
+				B43889B62A15DB4600476BFC /* Sources */,
+				B43889B72A15DB4600476BFC /* Frameworks */,
+				B43889B82A15DB4600476BFC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B43889BF2A15DB4600476BFC /* PBXTargetDependency */,
+			);
+			name = CAKKNetworkingTests;
+			productName = CAKKNetworkingTests;
+			productReference = B43889BA2A15DB4600476BFC /* CAKKNetworkingTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -443,6 +491,10 @@
 				TargetAttributes = {
 					8E9E192229CEDD4F00CFF157 = {
 						CreatedOnToolsVersion = 14.3;
+					};
+					B43889B92A15DB4600476BFC = {
+						CreatedOnToolsVersion = 14.3;
+						TestTargetID = 8E9E192229CEDD4F00CFF157;
 					};
 				};
 			};
@@ -460,6 +512,7 @@
 			projectRoot = "";
 			targets = (
 				8E9E192229CEDD4F00CFF157 /* CAKK */,
+				B43889B92A15DB4600476BFC /* CAKKNetworkingTests */,
 			);
 		};
 /* End PBXProject section */
@@ -486,6 +539,13 @@
 				8E37754D29F7CA2F00166198 /* Pretendard-Black.otf in Resources */,
 				B455C4382A07F06900FB8403 /* cake_shop_list_sample.json in Resources */,
 				8E9E193029CEDD5000CFF157 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B43889B82A15DB4600476BFC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -628,7 +688,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B43889B62A15DB4600476BFC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B43889BD2A15DB4600476BFC /* CAKKNetworkingTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		B43889BF2A15DB4600476BFC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8E9E192229CEDD4F00CFF157 /* CAKK */;
+			targetProxy = B43889BE2A15DB4600476BFC /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		8E9E193129CEDD5000CFF157 /* LaunchScreen.storyboard */ = {
@@ -828,6 +904,50 @@
 			};
 			name = Release;
 		};
+		B43889C02A15DB4600476BFC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = TZ3VZ8CUCV;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.MasonKim.CAKKNetworkingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CAKK.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/CAKK";
+			};
+			name = Debug;
+		};
+		B43889C12A15DB4600476BFC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = TZ3VZ8CUCV;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.MasonKim.CAKKNetworkingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CAKK.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/CAKK";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -845,6 +965,15 @@
 			buildConfigurations = (
 				8E9E193829CEDD5000CFF157 /* Debug */,
 				8E9E193929CEDD5000CFF157 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B43889C22A15DB4600476BFC /* Build configuration list for PBXNativeTarget "CAKKNetworkingTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B43889C02A15DB4600476BFC /* Debug */,
+				B43889C12A15DB4600476BFC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/CAKK/CAKK.xcodeproj/xcshareddata/xcschemes/CAKK.xcscheme
+++ b/CAKK/CAKK.xcodeproj/xcshareddata/xcschemes/CAKK.xcscheme
@@ -28,6 +28,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B43889B92A15DB4600476BFC"
+               BuildableName = "CAKKNetworkingTests.xctest"
+               BlueprintName = "CAKKNetworkingTests"
+               ReferencedContainer = "container:CAKK.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/CAKK/CAKK/Sources/Models/Store/CakeShop.swift
+++ b/CAKK/CAKK/Sources/Models/Store/CakeShop.swift
@@ -13,7 +13,7 @@ struct CakeShop: Decodable, Hashable {
   let modifiedAt: String
   let name: String
   let city: String
-  let district: District  // TODO: 해당 데이터를 District 타입으로 만들 수 있을 것 같은데, 백엔드 명세서의 예시 데이터가 나오지 않아 아직 알 수 없음...
+  let district: District
   let location: String
   let latitude: Double
   let longitude: Double

--- a/CAKK/CAKK/Sources/Network/CakeAPI.swift
+++ b/CAKK/CAKK/Sources/Network/CakeAPI.swift
@@ -75,15 +75,16 @@ extension CakeAPI: TargetType {
   }
   
   /// Moya Provider의 Stub Closure 에서 호출되는 SampleData
-  // TODO: 명세서의 example이 아직 정의되지 않음... / 현재는 예시로 넣어놓은 데이터...
   var sampleData: Data {
     switch self {
     case .fetchCakeShopList:
       return SampleData.cakeShopListData
     case .fetchDistrictCounts:
-      return Data()
+      return SampleData.districtCountData
     case .fetchCakeShopDetail:
       return SampleData.cakeShopDetailData
+      
+    // TODO: 블로그리뷰, 샵 이미지는 아직 명세 정해지지 않음
     case .fetchBlogReviews:
       return Data()
     case .fetchCakeShopImage:

--- a/CAKK/CAKK/Sources/Network/Tests/SampleData.swift
+++ b/CAKK/CAKK/Sources/Network/Tests/SampleData.swift
@@ -18,11 +18,20 @@ enum SampleData {
     return try? Data(contentsOf: location)
   }()
   
+  static let districtCountData: Data! = {
+    let location = Bundle.main.url(forResource: "district_count_sample", withExtension: "json")!
+    return try? Data(contentsOf: location)
+  }()
+  
   static let cakeShopList: [CakeShop]! = {
     return try? JSONDecoder().decode(CakeShopResponse.self, from: SampleData.cakeShopListData).cakeShops
   }()
   
   static let cakeShopDetail: CakeShopDetailResponse! = {
     return try? JSONDecoder().decode(CakeShopDetailResponse.self, from: SampleData.cakeShopDetailData)
+  }()
+  
+  static let districtCount: DistrictCountResponse! = {
+    return try? JSONDecoder().decode(DistrictCountResponse.self, from: SampleData.districtCountData)
   }()
 }

--- a/CAKK/CAKKNetworkingTests/CAKKNetworkingTests.swift
+++ b/CAKK/CAKKNetworkingTests/CAKKNetworkingTests.swift
@@ -22,7 +22,7 @@ final class CAKKNetworkingTests: XCTestCase {
     sut = nil
   }
   
-  func test_케이크리스트_Response_객체가_정상적으로_디코딩_된다() throws {
+  func test_케이크리스트_Response_객체가_정상적으로_디코딩_된다() {
     // given
     let expectation = XCTestExpectation()
     
@@ -42,7 +42,7 @@ final class CAKKNetworkingTests: XCTestCase {
     wait(for: [expectation], timeout: 2)
   }
   
-  func test_케이크상세정보_Response_객체가_정상적으로_디코딩_된다() throws {
+  func test_케이크상세정보_Response_객체가_정상적으로_디코딩_된다() {
     // given
     let expectation = XCTestExpectation()
     let expectatedData = SampleData.cakeShopDetail
@@ -63,7 +63,7 @@ final class CAKKNetworkingTests: XCTestCase {
     wait(for: [expectation], timeout: 2)
   }
 
-  func test_지역별_가게_갯수_Response_객체가_정상적으로_디코딩_된다() throws {
+  func test_지역별_가게_갯수_Response_객체가_정상적으로_디코딩_된다() {
     // given
     let expectation = XCTestExpectation()
     let expectatedData = SampleData.districtCount
@@ -78,6 +78,27 @@ final class CAKKNetworkingTests: XCTestCase {
         // then
         XCTAssertEqual(response.count, expectatedData?.count)
         expectation.fulfill()
+      }
+      .store(in: &cancellableBag)
+    
+    wait(for: [expectation], timeout: 2)
+  }
+  
+  func test_디코딩_실패시_적절한_에러를_밷는다() {
+    // given
+    let expectation = XCTestExpectation()
+    
+    // when
+    sut.request(.fetchCakeShopDetail(id: 0), type: DistrictCountResponse.self)
+      .sink { completion in
+        guard case .failure = completion else {
+          XCTFail("CakeShopDetailResponse 객체 디코딩 실패")
+          return
+        }
+        // then
+        expectation.fulfill()
+      } receiveValue: { _ in
+        XCTFail("타입이 일치하지 않으므로, 성공해서 들어오면 안됨")
       }
       .store(in: &cancellableBag)
     

--- a/CAKK/CAKKNetworkingTests/CAKKNetworkingTests.swift
+++ b/CAKK/CAKKNetworkingTests/CAKKNetworkingTests.swift
@@ -23,39 +23,64 @@ final class CAKKNetworkingTests: XCTestCase {
   }
   
   func test_케이크리스트_Response_객체가_정상적으로_디코딩_된다() throws {
+    // given
+    let expectation = XCTestExpectation()
+    
+    // when
     sut.request(.fetchCakeShopList(districts: [.dobong]), type: CakeShopResponse.self)
-      .sink { error in
-        print(error)
-        XCTFail("CakeShopResponse 객체 디코딩 실패")
+      .sink { completion in
+        if case let .failure(error) = completion {
+          XCTFail("CakeShopResponse 객체 디코딩 실패: \(error)")
+        }
       } receiveValue: { response in
+        // then
         XCTAssertGreaterThan(response.cakeShops.count, 0)
+        expectation.fulfill()
       }
       .store(in: &cancellableBag)
+    
+    wait(for: [expectation], timeout: 2)
   }
   
   func test_케이크상세정보_Response_객체가_정상적으로_디코딩_된다() throws {
-    let expectation = SampleData.cakeShopDetail
+    // given
+    let expectation = XCTestExpectation()
+    let expectatedData = SampleData.cakeShopDetail
     
+    // when
     sut.request(.fetchCakeShopDetail(id: 0), type: CakeShopDetailResponse.self)
-      .sink { error in
-        print(error)
-        XCTFail("CakeShopDetailResponse 객체 디코딩 실패")
+      .sink { completion in
+        if case let .failure(error) = completion {
+          XCTFail("CakeShopDetailResponse 객체 디코딩 실패: \(error)")
+        }
       } receiveValue: { response in
-        XCTAssertEqual(response.name, expectation?.name)
+        // then
+        XCTAssertEqual(response.name, expectatedData?.name)
+        expectation.fulfill()
       }
       .store(in: &cancellableBag)
+    
+    wait(for: [expectation], timeout: 2)
   }
 
   func test_지역별_가게_갯수_Response_객체가_정상적으로_디코딩_된다() throws {
-    let expectation = SampleData.districtCount
+    // given
+    let expectation = XCTestExpectation()
+    let expectatedData = SampleData.districtCount
     
+    // when
     sut.request(.fetchDistrictCounts, type: DistrictCountResponse.self)
-      .sink { error in
-        print(error)
-        XCTFail("DistrictCountResponse 객체 디코딩 실패")
+      .sink { completion in
+        if case let .failure(error) = completion {
+          XCTFail("DistrictCountResponse 객체 디코딩 실패: \(error)")
+        }
       } receiveValue: { response in
-        XCTAssertEqual(response.count, expectation?.count)
+        // then
+        XCTAssertEqual(response.count, expectatedData?.count)
+        expectation.fulfill()
       }
       .store(in: &cancellableBag)
+    
+    wait(for: [expectation], timeout: 2)
   }
 }

--- a/CAKK/CAKKNetworkingTests/CAKKNetworkingTests.swift
+++ b/CAKK/CAKKNetworkingTests/CAKKNetworkingTests.swift
@@ -6,30 +6,56 @@
 //
 
 import XCTest
+import Combine
+@testable import CAKK
 
 final class CAKKNetworkingTests: XCTestCase {
+  
+  var sut: NetworkService<CakeAPI>!
+  private var cancellableBag = Set<AnyCancellable>()
+  
+  override func setUpWithError() throws {
+    sut = NetworkService<CakeAPI>(type: .stub)
+  }
+  
+  override func tearDownWithError() throws {
+    sut = nil
+  }
+  
+  func test_케이크리스트_Response_객체가_정상적으로_디코딩_된다() throws {
+    sut.request(.fetchCakeShopList(districts: [.dobong]), type: CakeShopResponse.self)
+      .sink { error in
+        print(error)
+        XCTFail("CakeShopResponse 객체 디코딩 실패")
+      } receiveValue: { response in
+        XCTAssertGreaterThan(response.cakeShops.count, 0)
+      }
+      .store(in: &cancellableBag)
+  }
+  
+  func test_케이크상세정보_Response_객체가_정상적으로_디코딩_된다() throws {
+    let expectation = SampleData.cakeShopDetail
+    
+    sut.request(.fetchCakeShopDetail(id: 0), type: CakeShopDetailResponse.self)
+      .sink { error in
+        print(error)
+        XCTFail("CakeShopDetailResponse 객체 디코딩 실패")
+      } receiveValue: { response in
+        XCTAssertEqual(response.name, expectation?.name)
+      }
+      .store(in: &cancellableBag)
+  }
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
+  func test_지역별_가게_갯수_Response_객체가_정상적으로_디코딩_된다() throws {
+    let expectation = SampleData.districtCount
+    
+    sut.request(.fetchDistrictCounts, type: DistrictCountResponse.self)
+      .sink { error in
+        print(error)
+        XCTFail("DistrictCountResponse 객체 디코딩 실패")
+      } receiveValue: { response in
+        XCTAssertEqual(response.count, expectation?.count)
+      }
+      .store(in: &cancellableBag)
+  }
 }


### PR DESCRIPTION
서버의 데이터 타입 명세가 조금씩 바뀌어서 매번 테스트하기 귀찮아서 유닛 테스트로 구성함
각 Decodable 타입별로 JSON형태의 sample 데이터와 비교해서 디코딩이 잘 되는지 확인

- test_케이크리스트_Response_객체가_정상적으로_디코딩_된다
- test_케이크상세정보_Response_객체가_정상적으로_디코딩_된다
- test_지역별_가게_갯수_Response_객체가_정상적으로_디코딩_된다
- test_디코딩_실패시_적절한_에러를_밷는다