### PR TITLE
[Refactor] 지도 자연스러운 동작 구현 (마커 이동, 마커 선택 해제)

### DIFF
--- a/CAKK/CAKK.xcodeproj/project.pbxproj
+++ b/CAKK/CAKK.xcodeproj/project.pbxproj
@@ -736,6 +736,7 @@
 /* Begin XCBuildConfiguration section */
 		8E9E193529CEDD5000CFF157 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8EAD17232A166BB600E0C812 /* APIKeys.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -797,6 +798,7 @@
 		};
 		8E9E193629CEDD5000CFF157 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8EAD17232A166BB600E0C812 /* APIKeys.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;

--- a/CAKK/CAKK/Sources/ViewControllers/MainViewController.swift
+++ b/CAKK/CAKK/Sources/ViewControllers/MainViewController.swift
@@ -166,6 +166,9 @@ final class MainViewController: UIViewController {
     cakkMapView.didTappedMarker = { [weak self] cakeShop in
       self?.showCakeShopDetail(cakeShop)
     }
+    cakkMapView.didUnselectMarker = { [weak self] in
+      self?.hideCakeShopDetail()
+    }
   }
   
   private func setupSeeLocationButton() {

--- a/CAKK/CAKK/Sources/ViewControllers/MainViewController.swift
+++ b/CAKK/CAKK/Sources/ViewControllers/MainViewController.swift
@@ -30,8 +30,7 @@ final class MainViewController: UIViewController {
     static let horizontalPadding = 16.f
     static let verticalPadding = 24.f
     
-    static let naverMapViewHeightRatio = 0.5
-    static let naverMapBottomInset = 10.f
+    static let cakkMapBottomInset = 10.f
 
     static let seeLocationButtonBottomInset = 28.f
     
@@ -78,7 +77,7 @@ final class MainViewController: UIViewController {
   
   // MARK: - UI
   
-  private let naverMapView = CakkMapView(frame: .zero)
+  private let cakkMapView = CakkMapView(frame: .zero)
   
   private lazy var seeLocationButton = CapsuleStyleButton(
     iconImage: UIImage(systemName: "map")!,
@@ -132,8 +131,8 @@ final class MainViewController: UIViewController {
   }
   
   private func setupNaverMapViewLayout() {
-    view.addSubview(naverMapView)
-    naverMapView.snp.makeConstraints {
+    view.addSubview(cakkMapView)
+    cakkMapView.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
   }
@@ -163,8 +162,8 @@ final class MainViewController: UIViewController {
   }
   
   private func setupMapView() {
-    naverMapView.mapView.addCameraDelegate(delegate: self)
-    naverMapView.didTappedMarker = { [weak self] cakeShop in
+    cakkMapView.mapView.addCameraDelegate(delegate: self)
+    cakkMapView.didTappedMarker = { [weak self] cakeShop in
       self?.showCakeShopDetail(cakeShop)
     }
   }
@@ -180,7 +179,7 @@ final class MainViewController: UIViewController {
   private func setupCakeShopListBottomSheet() {
     // TODO: 변경
     let cakeListViewController = DIContainer.shared.makeCakeShopListViewController(with: .init(count: 3, color: .black, borderColor: .black, districts: [.jongno]))
-    naverMapView.bind(to: cakeListViewController.viewModel)
+    cakkMapView.bind(to: cakeListViewController.viewModel)
     
     cakeListViewController.cakeShopItemSelectAction = { [weak self] cakeShop in
       self?.showCakeShopDetail(cakeShop)
@@ -195,8 +194,8 @@ final class MainViewController: UIViewController {
     
     // Layout
     cakeShopListBottomSheet.snp.makeConstraints {
-      $0.top.equalTo(naverMapView.snp.bottom)
-        .inset(Metric.naverMapBottomInset)
+      $0.top.equalTo(cakkMapView.snp.bottom)
+        .inset(Metric.cakkMapBottomInset)
         .priority(.low)
     }
     

--- a/CAKK/CAKK/Sources/ViewControllers/MainViewController.swift
+++ b/CAKK/CAKK/Sources/ViewControllers/MainViewController.swift
@@ -215,6 +215,7 @@ final class MainViewController: UIViewController {
     hideDetailBottomSheetButton.tapPublisher
       .sink { [weak self] _ in
         self?.hideCakeShopDetail()
+        self?.cakkMapView.unselectMarker()
       }
       .store(in: &cancellableBag)
   }

--- a/CAKK/CAKK/Sources/ViewModels/CakeShopListViewModel.swift
+++ b/CAKK/CAKK/Sources/ViewModels/CakeShopListViewModel.swift
@@ -55,6 +55,12 @@ class CakeShopListViewModel {
       }
       .store(in: &cancellableBag)
     
+    input.unselectCakeShop
+      .sink {
+        
+      }
+      .store(in: &cancellableBag)
+    
     self.input = input
     self.output = output
   }

--- a/CAKK/CAKK/Sources/ViewModels/CakeShopListViewModel.swift
+++ b/CAKK/CAKK/Sources/ViewModels/CakeShopListViewModel.swift
@@ -55,12 +55,6 @@ class CakeShopListViewModel {
       }
       .store(in: &cancellableBag)
     
-    input.unselectCakeShop
-      .sink {
-        
-      }
-      .store(in: &cancellableBag)
-    
     self.input = input
     self.output = output
   }

--- a/CAKK/CAKK/Sources/ViewModels/CakeShopListViewModel.swift
+++ b/CAKK/CAKK/Sources/ViewModels/CakeShopListViewModel.swift
@@ -84,6 +84,7 @@ class CakeShopListViewModel {
           self?.output.hasNoData.send(false)
         }
 
+        print(cakeShops.map { $0.latitude })
         self?.output.cakeShops.send(cakeShops)
       }
       .store(in: &cancellableBag)

--- a/CAKK/CAKK/Sources/Views/CakkMapView.swift
+++ b/CAKK/CAKK/Sources/Views/CakkMapView.swift
@@ -56,6 +56,11 @@ final class CakkMapView: NMFNaverMapView {
       .store(in: &cancellableBag)
   }
   
+  func unselectMarker() {
+    selectedMarker?.iconImage = MarkerImage.pin
+    selectedMarker = nil
+  }
+  
   // MARK: - Private
   
   private func setupMapView() {
@@ -124,17 +129,10 @@ final class CakkMapView: NMFNaverMapView {
     marker.iconImage = MarkerImage.selectedPin
     
     if marker != selectedMarker {
-      unselectMarker(selectedMarker)
+      unselectMarker()
     }
     
     selectedMarker = marker
-  }
-  
-  private func unselectMarker(_ marker: NMFMarker?) {
-    marker?.iconImage = MarkerImage.pin
-    if marker == selectedMarker {
-      selectedMarker = nil
-    }
   }
   
   private func moveCamera(_ position: NMGLatLng) {
@@ -149,7 +147,7 @@ final class CakkMapView: NMFNaverMapView {
 extension CakkMapView: NMFMapViewTouchDelegate {
   // 맵뷰 마커가 아닌 다른 영역 선택 시 해당 마커를 해제하기 위함
   func mapView(_ mapView: NMFMapView, didTapMap latlng: NMGLatLng, point: CGPoint) {
-    unselectMarker(selectedMarker)
+    unselectMarker()
     didUnselectMarker?()
   }
 }


### PR DESCRIPTION
- [x] 특정 케이크샵 바텀시트에서 선택 시, 맵뷰 해당 위치로 케이크샵 마커 이동 구현
- [x] 맵뷰 마커가 아닌 부분 선택 시 선택 해제되게 구현 (네이버지도, 카카오맵과 동일한 동작)
- [x] 상세보기 해제 시 맵뷰의 마커 해제되게 구현