### PR TITLE
[Feat] scrollview tracking 삭제

### DIFF
--- a/CAKK/CAKK/Sources/ViewControllers/MainViewController.swift
+++ b/CAKK/CAKK/Sources/ViewControllers/MainViewController.swift
@@ -339,9 +339,7 @@ final class MainViewController: UIViewController {
     cakkMapView.bind(to: viewController.viewModel)
     
     updateFloatingPanelLayout()
-    
     cakeShopListFloatingPanel.set(contentViewController: viewController)
-    cakeShopListFloatingPanel.track(scrollView: viewController.collectionView)
     
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
       self?.cakeShopListFloatingPanel.move(to: .tip, animated: true)


### PR DESCRIPTION
- track 옵션을 삭제해야 full -> half로 이동했을때 scrollView가 top으로 이동하는 이슈 사라짐.
- 또한 half 모드에서도 scrollView를 조작하는게 사용자 경험에 더 적합하다 판단.
- 다만 full 상태에서 scrollView를 내렸을때 floating panel이 같이 따라 내려오지 않는다는 점에서 아쉬운점이 남음.