### PR TITLE
[Fix] CakeShop hash 기준 id에서 location으로 변경

### DIFF
--- a/CAKK/CAKK/Sources/Models/Store/CakeShop.swift
+++ b/CAKK/CAKK/Sources/Models/Store/CakeShop.swift
@@ -30,7 +30,7 @@ struct CakeShop: Decodable, Hashable {
   }
   
   func hash(into hasher: inout Hasher) {
-    hasher.combine(id)
+    hasher.combine(location)
   }
 }
 


### PR DESCRIPTION
- 어떤 이유인지는 모르겠으나 id를 기준으로 hashable 하게 만들면 아이템들이 중복되는 현상이 생김. 이랬을 때 location을 기준으로 하면 가장 정확하게 중복되지 않음. (추후 원인을 찾아봐야할듯)