### PR TITLE
[Refactor] 이미지 다운샘플링을 통한 메모리 최적화

### DIFF
--- a/CAKK/CAKK/Sources/Utils/Extensions/UIImageView+DownSampling.swift
+++ b/CAKK/CAKK/Sources/Utils/Extensions/UIImageView+DownSampling.swift
@@ -1,0 +1,40 @@
+//
+//  UIImageView+DownSampling.swift
+//  CAKK
+//
+//  Created by Mason Kim on 2023/08/10.
+//
+
+import Foundation
+import Kingfisher
+
+extension UIImageView {
+  private static let smallDownSamplingProcessor = DownsamplingImageProcessor(size: .init(width: 100, height: 100))
+  private static let middleDownSamplingProcessor = DownsamplingImageProcessor(size: .init(width: 200, height: 200))
+  
+  enum DownSamplingSize {
+    case small
+    case middle
+    
+    var processor: DownsamplingImageProcessor {
+      switch self {
+      case .small:
+        return UIImageView.smallDownSamplingProcessor
+      case .middle:
+        return UIImageView.middleDownSamplingProcessor
+      }
+    }
+  }
+  
+  func setDownsampledImage(url: URL?, size: DownSamplingSize = .small, placeholder: Placeholder? = nil) {
+    self.kf.setImage(
+      with: url,
+      placeholder: placeholder,
+      options: [
+        .processor(size.processor),
+        .scaleFactor(UIScreen.main.scale),
+        .cacheOriginalImage
+      ]
+    )
+  }
+}

--- a/CAKK/CAKK/Sources/Views/Cells/CakeImageCell.swift
+++ b/CAKK/CAKK/Sources/Views/Cells/CakeImageCell.swift
@@ -39,7 +39,7 @@ final class CakeImageCell: UICollectionViewCell {
   
   public func configure(imageURL: String) {
     guard let url = URL(string: imageURL) else { return }
-    imageView.kf.setImage(with: url)
+    imageView.setDownsampledImage(url: url)
   }
   
   

--- a/CAKK/CAKK/Sources/Views/Cells/FeedCell.swift
+++ b/CAKK/CAKK/Sources/Views/Cells/FeedCell.swift
@@ -46,7 +46,7 @@ final class FeedCell: UICollectionViewCell {
   
   private func configureImage(_ imageUrl: String) {
     let url = URL(string: imageUrl)
-    imageView.kf.setImage(with: url)
+    imageView.setDownsampledImage(url: url)
   }
 }
 

--- a/CAKK/CAKK/Sources/Views/UIControlImageView.swift
+++ b/CAKK/CAKK/Sources/Views/UIControlImageView.swift
@@ -60,7 +60,7 @@ class UIControlImageView: UIControl {
   
   public func setImage(urlString: String, placeholder: UIImage? = nil) {
     let url = URL(string: urlString)
-    imageView.kf.setImage(with: url, placeholder: placeholder)
+    imageView.setDownsampledImage(url: url, placeholder: placeholder)
   }
   
   public func setupCornerRadius(_ radius: CGFloat) {


### PR DESCRIPTION
피드나 전체적으로 이미지를 너무 크게 사용하고 있던 현상 발생

> 피드를 쭉 내렸을 때 메모리를 과하게 소모하는 상황

![image](https://github.com/Prography-8th-team8/team8-iOS/assets/59835351/55d50926-9f73-4a52-9fae-237bd1fa3c00)

> 피드에 Downsampling을 적용함으로서 메모리 사용량을 1/3 이상으로 줄임.

![image](https://github.com/Prography-8th-team8/team8-iOS/assets/59835351/0e739785-3758-4e99-97dc-dcefcb43b39d)
