### PR TITLE
[Fix] 다운샘플링 이미지가 기본 이미지에도 적용되는 현상 해결

### DIFF
--- a/CAKK/CAKK/Sources/Utils/Extensions/UIImageView+DownSampling.swift
+++ b/CAKK/CAKK/Sources/Utils/Extensions/UIImageView+DownSampling.swift
@@ -26,15 +26,26 @@ extension UIImageView {
     }
   }
   
-  func setDownsampledImage(url: URL?, size: DownSamplingSize = .small, placeholder: Placeholder? = nil) {
+  /// 다운샘플링 한 이미지를 이미지뷰에 지정하고, 캐시에 저장합니다.
+  ///
+  /// 캐시 키가 다르기 때문에 다운샘플링 되지 않은 원본 이미지를 지정하려면 기존 `kf.setImage` 를 사용하면 따로 처리됩니다.
+  func setDownsampledImage(with url: URL?,
+                           size: DownSamplingSize = .small,
+                           placeholder: Placeholder? = nil,
+                           completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) {
+    guard let url else { return }
+    let cacheKey = "\(url.absoluteString)-downsampled-\(size)"
+    let resource = ImageResource(downloadURL: url, cacheKey: cacheKey)
+    
     self.kf.setImage(
-      with: url,
+      with: resource,
       placeholder: placeholder,
       options: [
         .processor(size.processor),
         .scaleFactor(UIScreen.main.scale),
         .cacheOriginalImage
-      ]
+      ],
+      completionHandler: completionHandler
     )
   }
 }

--- a/CAKK/CAKK/Sources/Views/Cells/CakeImageCell.swift
+++ b/CAKK/CAKK/Sources/Views/Cells/CakeImageCell.swift
@@ -39,7 +39,7 @@ final class CakeImageCell: UICollectionViewCell {
   
   public func configure(imageURL: String) {
     guard let url = URL(string: imageURL) else { return }
-    imageView.setDownsampledImage(url: url)
+    imageView.setDownsampledImage(with: url)
   }
   
   

--- a/CAKK/CAKK/Sources/Views/Cells/FeedCell.swift
+++ b/CAKK/CAKK/Sources/Views/Cells/FeedCell.swift
@@ -46,7 +46,7 @@ final class FeedCell: UICollectionViewCell {
   
   private func configureImage(_ imageUrl: String) {
     let url = URL(string: imageUrl)
-    imageView.setDownsampledImage(url: url)
+    imageView.setDownsampledImage(with: url)
   }
 }
 

--- a/CAKK/CAKK/Sources/Views/UIControlImageView.swift
+++ b/CAKK/CAKK/Sources/Views/UIControlImageView.swift
@@ -60,7 +60,7 @@ class UIControlImageView: UIControl {
   
   public func setImage(urlString: String, placeholder: UIImage? = nil) {
     let url = URL(string: urlString)
-    imageView.setDownsampledImage(url: url, placeholder: placeholder)
+    imageView.setDownsampledImage(with: url, placeholder: placeholder)
   }
   
   public func setupCornerRadius(_ radius: CGFloat) {


### PR DESCRIPTION
- 원본 이미지를 적용하고 싶을 수 있기에, 다운샘플링 시 key값을 따로 지정하여 캐싱하도록 함